### PR TITLE
Fix Fc's when using vol+zoom having an IndexOutOfBoundsException.

### DIFF
--- a/src/com/android/camera/VideoCamera.java
+++ b/src/com/android/camera/VideoCamera.java
@@ -1747,7 +1747,10 @@ public class VideoCamera extends BaseCamera
 
         // Maximum zoom value may change after preview size is set. Get the
         // latest parameters here.
-        mZoomMax = mParameters.getMaxZoom();
+        /*
+        	Max zoom value can not be more than zoomRatios.
+         */
+	      mZoomMax = mParameters.getZoomRatios().size() -1;
         mGestureDetector = new GestureDetector(this, new ZoomGestureListener());
 
         mCameraDevice.setZoomChangeListener(mZoomListener);


### PR DESCRIPTION
Initialize max zoom to zoomRatios because max zoom value can not be more than zoomRatios.
Tested on z71, ZERO and Nexus One.
